### PR TITLE
Update 64tass package to 1.54.1900

### DIFF
--- a/.AURINFO
+++ b/.AURINFO
@@ -1,12 +1,11 @@
 pkgbase = 64tass
 	pkgdesc = 6502/65C02/R65C02/W65C02/65CE02/65816/DTV/65EL02 Turbo Assembler
-	pkgver = 1.51.727
+	pkgver = 1.54.1900
 	pkgrel = 1
 	url = http://tass64.sourceforge.net
 	arch = i686
 	arch = x86_64
 	license = GPL
-	makedepends = subversion
 	conflicts = 64tass-svn
 	source = http://downloads.sourceforge.net/project/tass64/source/64tass-1.51.727-src.zip
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,15 +2,14 @@
 # Maintainer: lobotomius at gmail dot com
 
 pkgname=64tass
-pkgver=1.51.727
+pkgver=1.54.1900
 pkgrel=1
 pkgdesc="6502/65C02/R65C02/W65C02/65CE02/65816/DTV/65EL02 Turbo Assembler"
 arch=('i686' 'x86_64')
 url='http://tass64.sourceforge.net'
 license=('GPL')
-makedepends=('subversion')
 source=("http://downloads.sourceforge.net/project/tass64/source/64tass-$pkgver-src.zip")
-md5sums=('11b48f5dc466053f35b3bbf45405d911')
+md5sums=('a06434a6c8b82baafaa72126a2f7ef0e')
 conflicts=("64tass-svn")
 
 build() {


### PR DESCRIPTION
This upgrades the 64tass package to 1.54.1900. It also drops the dependency on `subversion`, which is not required to build (or use) the package.